### PR TITLE
Include completion scripts during installation

### DIFF
--- a/kubetail.rb
+++ b/kubetail.rb
@@ -7,6 +7,9 @@ class Kubetail < Formula
 
   def install
     bin.install "kubetail"
+    bash_completion.install "completion/kubetail.bash"
+    zsh_completion.install "completion/kubetail.zsh" => "_kubetail"
+    fish_completion.install "completion/kubetail.fish"
   end
 
   test do


### PR DESCRIPTION
Include completion scripts during installation.  This will probably need to wait to be merged until the next version bump, as the files don't currently exist in 1.5.

Example taken from: https://github.com/Homebrew/homebrew-core/blob/1e9869f51a3309ed8f2fb02b17a92f39aa2dc665/Formula/youtube-dl.rb